### PR TITLE
Dispatch custom event when user accepts the policy

### DIFF
--- a/src/js/public/gdpr-public.js
+++ b/src/js/public/gdpr-public.js
@@ -116,6 +116,7 @@
 							$(window).scrollTop(Math.abs( parseInt( scrollDistance, 10 ) ) );
 							$('.gdpr.gdpr-privacy-preferences .gdpr-wrapper').fadeOut();
 							$('.gdpr-privacy-bar').fadeOut();
+							$( document ).trigger( "updatedPrivacyPreferences" );
 						}
 					} else {
 						displayNotification( response.data.title, response.data.content );

--- a/src/js/public/gdpr-public.js
+++ b/src/js/public/gdpr-public.js
@@ -116,7 +116,7 @@
 							$(window).scrollTop(Math.abs( parseInt( scrollDistance, 10 ) ) );
 							$('.gdpr.gdpr-privacy-preferences .gdpr-wrapper').fadeOut();
 							$('.gdpr-privacy-bar').fadeOut();
-							$( document ).trigger( "updatedPrivacyPreferences" );
+							$( document ).trigger( 'updatedPrivacyPreferences' );
 						}
 					} else {
 						displayNotification( response.data.title, response.data.content );


### PR DESCRIPTION
Copy of upstream PR - https://github.com/trewknowledge/GDPR/pull/245

Dispatch a custom event so we can do "interesting things" from elsewhere when the user accepts the policy.

In my example I want to redirect the user to the same page, but with a cache buster on the end of the URL:

```
jQuery( document )
	.on(
		"updatedPrivacyPreferences",
		function() {
			"use strict";

			var current_url = encodeURI( window.location.href );
			var qs_concat = current_url.indexOf( "?" ) > -1 ? "&" : "?";

			window.location = encodeURI( current_url + qs_concat + "ts=" + new Date().getTime() );
		}
	);
```