### PR TITLE
[BUG] Fixes escaped output of cookie value to allow double quotes

### DIFF
--- a/public/class-gdpr-cookie-setting-js.php
+++ b/public/class-gdpr-cookie-setting-js.php
@@ -62,7 +62,7 @@ class Gdpr_Cookie_Setting_Js {
 		}
 
 		echo '<script type="text/javascript">',
-			"document.cookie = '" . esc_js( $cookie_val ) . "'",
+			"document.cookie = '" . wp_kses_post( $cookie_val ) . "'",
 		'</script>';
 
 		return true;


### PR DESCRIPTION
**Note**: ignore the Travis fails - known issue, fix in progress elsewhere.

Current `esc_js` ends up with arrays converted to just `[&quot`, which breaks the expectation of a valid array:

```
Warning: array_map(): Argument #2 should be an array in /vagrant/wp-content/plugins/gdpr/includes/helper-functions.php on line 88

Warning: preg_grep() expects parameter 2 to be array, null given in /vagrant/wp-content/plugins/gdpr/includes/helper-functions.php on line 90

Warning: in_array() expects parameter 2 to be array, null given in /vagrant/wp-content/plugins/gdpr/includes/helper-functions.php on line 91

Warning: array_map(): Argument #2 should be an array in /vagrant/wp-content/plugins/gdpr/includes/helper-functions.php on line 88

Warning: preg_grep() expects parameter 2 to be array, null given in /vagrant/wp-content/plugins/gdpr/includes/helper-functions.php on line 90

Warning: in_array() expects parameter 2 to be array, null given in /vagrant/wp-content/plugins/gdpr/includes/helper-functions.php on line 91
```

`wp_kses` (did you know, pronounced Kisses... 👄) seems to allow double quotes, making the world right again.