### PR TITLE
[PEAKE-820][FEATURE] Revert to setcookie except for init hook

### DIFF
--- a/admin/class-gdpr-admin.php
+++ b/admin/class-gdpr-admin.php
@@ -922,8 +922,10 @@ class GDPR_Admin {
 			GDPR_Audit_Log::log( $user_id, $consent );
 		}
 
-		(new Gdpr_Cookie_Setting_Js())
-			->js_setcookie( 'gdpr[consent_types]', wp_json_encode( $consents ), time() + YEAR_IN_SECONDS, '/' );
+		// This only happens on a POST request and should have no impact on caching.
+		// phpcs:disable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
+		setcookie( 'gdpr[consent_types]', wp_json_encode( $consents ), time() + YEAR_IN_SECONDS, '/' );
+		// phpcs:enable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
 	}
 
 	/**

--- a/gdpr.php
+++ b/gdpr.php
@@ -16,7 +16,7 @@
  * Plugin Name:       GDPR
  * Plugin URI:        https://trewknowledge.com
  * Description:       This plugin is meant to assist a Controller, Data Processor, and Data Protection Officer (DPO) with efforts to meet the obligations and rights enacted under the GDPR.
- * Version:           3.9.1
+ * Version:           3.10.0
  * Author:            Box UK (forked from Trew Knowledge)
  * Author URI:        https://trewknowledge.com
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'GDPR_VERSION', '3.9.1' );
+define( 'GDPR_VERSION', '3.10.0' );
 
 /**
  * The minimum PHP version required to run the plugin.

--- a/includes/class-gdpr.php
+++ b/includes/class-gdpr.php
@@ -272,12 +272,10 @@ class GDPR {
 
 		$plugin_public   = new GDPR_Public( $this->get_plugin_name(), $this->get_version() );
 		$requests_public = new GDPR_Requests_Public( $this->get_plugin_name(), $this->get_version() );
-		$cookie_setting_public = new Gdpr_Cookie_Setting_Js();
 
 		add_action( 'wp_enqueue_scripts', array( $plugin_public, 'enqueue_styles' ) );
 		add_action( 'wp_enqueue_scripts', array( $plugin_public, 'enqueue_scripts' ) );
 		add_action( 'init', array( $plugin_public, 'set_plugin_cookies' ) );
-		add_action( 'init', array( $cookie_setting_public, 'set_cookies_from_transients_on_page_load' ) );
 		add_action( 'wp_footer', array( $plugin_public, 'overlay' ) );
 		add_action( 'wp_footer', array( $plugin_public, 'privacy_bar' ) );
 		add_action( 'wp_footer', array( $plugin_public, 'is_consent_needed' ) );
@@ -344,8 +342,10 @@ class GDPR {
 				GDPR_Audit_Log::log( $user_id, sprintf( esc_html__( 'User gave explicit consent to %s', 'gdpr' ), $consent ) );
 				add_user_meta( $user_id, 'gdpr_consents', $consent );
 			}
-			(new Gdpr_Cookie_Setting_Js())
-				->js_setcookie( 'gdpr[consent_types]', wp_json_encode( $consents ), time() + YEAR_IN_SECONDS, '/' );
+			// This only happens on a POST request and should have no impact on caching.
+			// phpcs:disable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
+			setcookie( 'gdpr[consent_types]', wp_json_encode( $consents ), time() + YEAR_IN_SECONDS, '/' );
+			// phpcs:enable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
 		}
 	}
 
@@ -650,8 +650,10 @@ class GDPR {
 			if ( in_array( $consent, $consent_ids, true ) && ! in_array( $consent, $user_consent, true ) ) {
 				add_user_meta( $user_id, 'gdpr_consents', $consent );
 				$user_consent[] = $consent;
-				(new Gdpr_Cookie_Setting_Js())
-					->js_setcookie( 'gdpr[consent_types]', wp_json_encode( $user_consent ), time() + YEAR_IN_SECONDS, '/' );
+				// This only happens on a POST request and should have no impact on caching.
+				// phpcs:disable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
+				setcookie( 'gdpr[consent_types]', wp_json_encode( $user_consent ), time() + YEAR_IN_SECONDS, '/' );
+				// phpcs:enable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
 				return true;
 			}
 		}
@@ -678,8 +680,10 @@ class GDPR {
 			if ( false !== $key ) {
 				delete_user_meta( $user_id, 'gdpr_consents', $consent );
 				unset( $user_consent[ $key ] );
-				(new Gdpr_Cookie_Setting_Js())
-					->js_setcookie( 'gdpr[consent_types]', wp_json_encode( $user_consent ), time() + YEAR_IN_SECONDS, '/' );
+				// This only happens on a POST request and should have no impact on caching.
+				// phpcs:disable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
+				setcookie( 'gdpr[consent_types]', wp_json_encode( $user_consent ), time() + YEAR_IN_SECONDS, '/' );
+				// phpcs:enable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
 				return true;
 			}
 		}

--- a/public/class-gdpr-cookie-setting-js.php
+++ b/public/class-gdpr-cookie-setting-js.php
@@ -22,24 +22,6 @@ class Gdpr_Cookie_Setting_Js {
 	private const GMT_DATE_FORMAT = 'D, d M Y H:i:s \G\M\T';
 
 	/**
-	 * The transient prefix.
-	 */
-	private const TRANSIENT_PREFIX = 'gdpr_cookie_setting_';
-
-	/**
-	 * When the transient should expire - 60s * 60m = 1 hour.
-	 */
-	private const EXPIRES_IN = 60 * 60;
-
-	/**
-	 * The GDPR Plugin uses these cookie
-	 */
-	private const GDPR_COOKIES = [
-		'gdpr[allowed_cookies]',
-		'gdpr[consent_types]',
-	];
-
-	/**
 	 * A wrapper to ensure this code is added to the page footer.
 	 *
 	 * @param string $name the cookie name.
@@ -58,51 +40,6 @@ class Gdpr_Cookie_Setting_Js {
 			function() use ( $name, $value, $expires, $path, $domain ) : bool {
 				return $this->set_cookie( $name, $value, $expires, $path, $domain );
 			}
-		);
-
-		/**
-		 * When a site visitors accepts the Cookie Policy / GDPR Cookie Bar, this is sent in to WP as an AJAX request.
-		 * The hook above will attempt to run on that AJAX request. This will not have the expected / intended outcome.
-		 *
-		 * Therefore, by saving the cookie data to a WP transient, we can check for the existence of that transient
-		 * on the next "typical" web request, and set the cookies on that request, which does give the desired outcome.
-		 */
-		$transient_name = $this->get_transient_name( $name );
-
-		$data = [$name, $value, $expires, $path, $domain];
-
-		set_site_transient( $transient_name, $data, self::EXPIRES_IN );
-	}
-
-	/**
-	 * For each of the `GDPR_Cookies`, write any saved cookie information for the visitor, as per the data they have
-	 * stored in transients on previous requests.
-	 */
-	public function set_cookies_from_transients_on_page_load(): void {
-		array_map(
-			function ( string $cookie_name ) : bool {
-				$transient_name = $this->get_transient_name( $cookie_name );
-
-				$data = get_site_transient( $transient_name );
-
-				delete_site_transient( $transient_name );
-
-				if ( false === $data ) {
-					return false;
-				}
-
-				[$name, $value, $expires, $path, $domain] = $data;
-
-				add_action(
-					'wp_footer',
-					function() use ( $name, $value, $expires, $path, $domain ) : bool {
-						return $this->set_cookie( $name, $value, $expires, $path, $domain );
-					}
-				);
-
-				return true;
-			},
-			self::GDPR_COOKIES
 		);
 	}
 
@@ -141,20 +78,5 @@ class Gdpr_Cookie_Setting_Js {
 		'</script>';
 
 		return true;
-	}
-
-	/**
-	 * Example outcomes:
-	 *
-	 * gdpr_cookie_setting_gdpr[allowed_cookies]_4ffc0746ac855d3b4a6094c7978198a3
-	 * gdpr_cookie_setting_gdpr[consent_types]_4ffc0746ac855d3b4a6094c7978198a3
-	 *
-	 * The COOKIEHASH should always be the same for a given session.
-	 *
-	 * @param string $cookie_name the cookie name.
-	 * @return mixed|void
-	 */
-	private function get_transient_name( string $cookie_name ) {
-		return apply_filters( 'woocommerce_cookie', self::TRANSIENT_PREFIX  . $cookie_name . '_' . COOKIEHASH );
 	}
 }

--- a/public/class-gdpr-public.php
+++ b/public/class-gdpr-public.php
@@ -245,10 +245,11 @@ class GDPR_Public {
 		$cookies_as_json  = wp_json_encode( $approved_cookies );
 		$consents_as_json = wp_json_encode( $consents );
 
-		(new Gdpr_Cookie_Setting_Js())
-			->js_setcookie( 'gdpr[allowed_cookies]', $cookies_as_json, time() + YEAR_IN_SECONDS, '/' );
-		(new Gdpr_Cookie_Setting_Js())
-			->js_setcookie( 'gdpr[consent_types]', $consents_as_json, time() + YEAR_IN_SECONDS, '/' );
+		// This only happens on a POST request and should have no impact on caching.
+		// phpcs:disable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
+		setcookie( 'gdpr[allowed_cookies]', $cookies_as_json, time() + YEAR_IN_SECONDS, '/' );
+		setcookie( 'gdpr[consent_types]', $consents_as_json, time() + YEAR_IN_SECONDS, '/' );
+		// phpcs:enable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
 
 		foreach ( $cookies_to_remove as $cookie ) {
 			// Approved usage by VIP support.
@@ -258,10 +259,12 @@ class GDPR_Public {
 				$domain = wp_parse_url( $domain, PHP_URL_HOST );
 				unset( $_COOKIE[ $cookie ] ); // WPCS: Input var ok.
 				// phpcs:enable WordPress.VIP.RestrictedVariables.cache_constraints___COOKIE
-				(new Gdpr_Cookie_Setting_Js())
-					->js_setcookie( $cookie, null, -1, '/', $domain );
-				(new Gdpr_Cookie_Setting_Js())
-					->js_setcookie( $cookie, null, -1, '/', '.' . $domain );
+
+				// This only happens on a POST request and should have no impact on caching.
+				// phpcs:disable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
+				setcookie( $cookie, null, -1, '/', $domain );
+				setcookie( $cookie, null, -1, '/', '.' . $domain );
+				// phpcs:enable WordPressVIPMinimum.VIP.RestrictedFunctions.cookies_setcookie
 			}
 		}
 


### PR DESCRIPTION
Revert to using `setcookie` approach for (almost) all of the places where cookies are written.

There is one that remains using JS:

https://github.com/boxuk/GDPR/blob/master/includes/class-gdpr.php#L279

This is, afaik, the *only* place that causes an issue with VIP page caching.

On each page load, in the GDPR plugin by default, `set_plugin_cookie` is always called, using that above hook. 

This function has been modified in the boxuk/GDPR repo to use JS for setting cookies (https://github.com/boxuk/GDPR/blob/master/public/class-gdpr-public.php#L346). 

This PR keeps this method - using JS for this specific function. This means any `GET` requests will use JS for initial cookie setting. This should keep the code VIP caching compliant.

For all other requests - all of which are `POST` (typically AJAX) requests, this PR reverts to using `setcookie`.

By using `setcookie`, the cookie(s) will be correctly written when the AJAX / `POST` request is sent in. When using the JS approach, the HTML needs writing and *parsing* client side to enact the cookie change. This means a weird double reload is required, which proved flaky. 

Reverting to `setcookie` as above fixes this problem, and should have no impact on caching, as all of these requests are user initiated.    