### PR TITLE
[BUG] Check wpcom_vip function exists before using it

### DIFF
--- a/includes/class-gdpr-audit-log.php
+++ b/includes/class-gdpr-audit-log.php
@@ -167,12 +167,21 @@ class GDPR_Audit_Log {
 		$path        = $basedir . '/gdpr_logs/';
 		if ( wp_mkdir_p( $path ) ) {
 			if ( ! file_exists( $path . 'index.php' ) ) {
-				wpcom_vip_file_put_contents( $path . 'index.php', '' );
+				if ( function_exists( 'wpcom_vip_file_put_contents' ) ) {
+					wpcom_vip_file_put_contents( $path . 'index.php', '' );
+				} else {
+					file_put_contents( $path . 'index.php', '' );
+				}
 			}
 			$log      = self::get_log( $user->user_email );
 			$filename = self::email_mask( $user->user_email . $token );
 			$filename = base64_encode( $filename );
-			wpcom_vip_file_put_contents( $path . $filename, self::crypt( $user->user_email, $log ) );
+			$encrypted_log_message = self::crypt( $user->user_email, $log );
+			if ( function_exists( 'wpcom_vip_file_put_contents' ) ) {
+				wpcom_vip_file_put_contents( $path . $filename, $encrypted_log_message );
+			} else {
+				file_put_contents( $path . $filename, $encrypted_log_message );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Check that `wpcom_vip_file_put_contents` function exists before trying
to use it.

I can't find any documentation on this function, but presumably it's for
working with VIP's filesystem. Although the beginning of this function
does seem to suggest that this won't work on VIP environments anyway...

Currently causes a fatal error while I'm trying to test the GDPR plugin
on my local environment.

This function was originally added in a commit for "PHPCS fixes"

https://github.com/boxuk/GDPR/pull/40/commits/eabd9f14341c11be2657db8f6b49c45f543027c9#diff-ea4ff831e9f6ef28b1793cd99973b9947370d9c3603059927d5c99487db97987L174